### PR TITLE
Fix issues with build_src_filter

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,7 @@ board         = esp32doit-devkit-v1
 
 build_flags   = ${common.build_flags}
 	-D SERIAL_PLOTTER
-build_src_filter    = ${common.src_filter}
+build_src_filter    = ${common.build_src_filter}
 lib_deps      = ${common.lib_deps}
 upload_speed  = 921600
 
@@ -45,5 +45,5 @@ build_flags = ${common.build_flags}
 	-D OHA_CHEST_FRONT_COLS=4
 	-D OHA_CHEST_BACK_ROWS=5
 	-D OHA_CHEST_BACK_COLS=4
-build_src_filter  = ${common.src_filter}
+build_src_filter  = ${common.build_src_filter}
 	+<modes/auto_precompiled.cpp>


### PR DESCRIPTION
When i changed `src_filter` to `build_src_filter` i missed it in a couple of places.