### PR TITLE
feat: generate unique SN for each device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,14 @@ jobs:
           - bhaptics_tactsuit_x16
           - bhaptics_tactsuit_x16_pca9685
           - bhaptics_tactsuit_x40
+          - bhaptics_tactosy2_forearm_left
+          - bhaptics_tactosy2_forearm_right
+          - bhaptics_tactosyh_hand_left
+          - bhaptics_tactosyh_hand_right
+          - bhaptics_tactosyf_foot_left
+          - bhaptics_tactosyf_foot_right
+          - bhaptics_tactal
+          - bhaptics_tactot_dk3
 
     steps:
     - uses: actions/checkout@v3

--- a/ini/bhaptics.ini
+++ b/ini/bhaptics.ini
@@ -11,7 +11,7 @@ build_flags = ${bhaptics.build_flags}
 	-D BH_BLE_APPEARANCE=510
 	'-D BLUETOOTH_NAME="TactSuitX16"'
 	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
-	'-D BH_SERIAL_NUMBER={ 0x24, 0xe6, 0xe0, 0x52, 0x3d, 0x66, 0x29, 0xc7, 0xce, 0xed }'
+	'-D BH_SERIAL_NUMBER={ 0x0d, 0x3a, 0xeb, 0x77, 0xbe, 0xf8, 0x7a, 0x1e, 0x3b, 0x2a }'
 	'-D BLUETOOTH_ADDRESS={ 0xe7, 0x59, 0xfe, 0x5e, 0xb4, 0x34 }'
 build_src_filter  = ${bhaptics.build_src_filter}
 	+<modes/bhaptics/tactsuit_x16.cpp>
@@ -22,7 +22,7 @@ build_flags = ${bhaptics.build_flags}
 	-D BH_BLE_APPEARANCE=510
 	'-D BLUETOOTH_NAME="TactSuitX16"'
 	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
-	'-D BH_SERIAL_NUMBER={ 0x24, 0xe6, 0xe0, 0x52, 0x3d, 0x66, 0x29, 0xc7, 0xce, 0xed }'
+	'-D BH_SERIAL_NUMBER={ 0x0d, 0x3a, 0xeb, 0x77, 0xbe, 0xf8, 0x7a, 0x1e, 0x3b, 0x2a }'
 	'-D BLUETOOTH_ADDRESS={ 0xe7, 0x59, 0xfe, 0x5e, 0xb4, 0x34 }'
 build_src_filter  = ${bhaptics.build_src_filter}
 	+<modes/bhaptics/tactsuit_x16_pca9685.cpp>
@@ -33,39 +33,70 @@ build_flags = ${bhaptics.build_flags}
 	-D BH_BLE_APPEARANCE=509
 	'-D BLUETOOTH_NAME="TactSuitX40"'
 	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
-	'-D BH_SERIAL_NUMBER={ 0x24, 0xe6, 0xe0, 0x52, 0x3d, 0x66, 0x29, 0xc7, 0xce, 0xed }'
+	'-D BH_SERIAL_NUMBER={ 0xcf, 0xcb, 0x0d, 0x95, 0x5f, 0xf6, 0xee, 0x2c, 0xbd, 0x73 }'
 	'-D BLUETOOTH_ADDRESS={ 0xe7, 0x59, 0xff, 0x5c, 0xb4, 0x34 }'
 build_src_filter  = ${bhaptics.build_src_filter}
 	+<modes/bhaptics/tactsuit_x40.cpp>
 lib_deps    = ${bhaptics.lib_deps}
 
-[env:bhaptics_tactosy2_forearm]
+[env:bhaptics_tactosy2_forearm_left]
 build_flags = ${bhaptics.build_flags}
 	-D BH_BLE_APPEARANCE=508
-	'-D BLUETOOTH_NAME="Tactosy2_"'
+	'-D BLUETOOTH_NAME="Tactosy2_L"'
 	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
-	'-D BH_SERIAL_NUMBER={ 0x24, 0xe6, 0xe0, 0x52, 0x3d, 0x66, 0x29, 0xc7, 0xce, 0xed }'
+	'-D BH_SERIAL_NUMBER={ 0xa0, 0xba, 0x0a, 0xd1, 0xbf, 0x36, 0x11, 0x30, 0xa4, 0xff }'
 	'-D BLUETOOTH_ADDRESS={ 0xe7, 0x59, 0xff, 0x5b, 0xb4, 0x34 }'
 build_src_filter  = ${bhaptics.build_src_filter}
 	+<modes/bhaptics/tactosy2.cpp>
 lib_deps    = ${bhaptics.lib_deps}
 
-[env:bhaptics_tactosyh_hand]
+[env:bhaptics_tactosy2_forearm_right]
 build_flags = ${bhaptics.build_flags}
 	-D BH_BLE_APPEARANCE=508
-	'-D BLUETOOTH_NAME="TactosyH_V2"'
+	'-D BLUETOOTH_NAME="Tactosy2_R"'
 	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
-	'-D BH_SERIAL_NUMBER={ 0x24, 0xe6, 0xe0, 0x52, 0x3d, 0x66, 0x29, 0xc7, 0xce, 0xed }'
+	'-D BH_SERIAL_NUMBER={ 0xb0, 0x1c, 0xc1, 0xf8, 0xec, 0x12, 0x18, 0x4e, 0x09, 0x77 }'
+	'-D BLUETOOTH_ADDRESS={ 0xe7, 0x59, 0xff, 0x5b, 0xb4, 0x34 }'
+build_src_filter  = ${bhaptics.build_src_filter}
+	+<modes/bhaptics/tactosy2.cpp>
+lib_deps    = ${bhaptics.lib_deps}
+
+[env:bhaptics_tactosyh_hand_left]
+build_flags = ${bhaptics.build_flags}
+	-D BH_BLE_APPEARANCE=508
+	'-D BLUETOOTH_NAME="TactosyH_L"'
+	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
+	'-D BH_SERIAL_NUMBER={ 0xc1, 0x36, 0xdc, 0x21, 0xc9, 0xd4, 0x17, 0x85, 0xbb, 0x90 }'
 build_src_filter  = ${bhaptics.build_src_filter}
 	+<modes/bhaptics/tactosyh.cpp>
 lib_deps    = ${bhaptics.lib_deps}
 
-[env:bhaptics_tactosyf_foot]
+[env:bhaptics_tactosyh_hand_right]
 build_flags = ${bhaptics.build_flags}
 	-D BH_BLE_APPEARANCE=508
-	'-D BLUETOOTH_NAME="TactosyF_"'
+	'-D BLUETOOTH_NAME="TactosyH_R"'
 	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
-	'-D BH_SERIAL_NUMBER={ 0x24, 0xe6, 0xe0, 0x52, 0x3d, 0x66, 0x29, 0xc7, 0xce, 0xed }'
+	'-D BH_SERIAL_NUMBER={ 0xc7, 0x5f, 0x3b, 0x06, 0x38, 0xba, 0x34, 0xfa, 0x36, 0xc1 }'
+build_src_filter  = ${bhaptics.build_src_filter}
+	+<modes/bhaptics/tactosyh.cpp>
+lib_deps    = ${bhaptics.lib_deps}
+
+[env:bhaptics_tactosyf_foot_left]
+build_flags = ${bhaptics.build_flags}
+	-D BH_BLE_APPEARANCE=508
+	'-D BLUETOOTH_NAME="TactosyF_L"'
+	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
+	'-D BH_SERIAL_NUMBER={ 0x1a, 0x45, 0x83, 0x44, 0x03, 0xc5, 0xf3, 0xc3, 0xf3, 0xb8 }'
+build_src_filter  = ${bhaptics.build_src_filter}
+	+<modes/bhaptics/tactosyf.cpp>
+lib_deps    = ${bhaptics.lib_deps}
+
+[env:bhaptics_tactosyf_foot_right]
+build_flags = ${bhaptics.build_flags}
+	-D BH_BLE_APPEARANCE=508
+	'-D BLUETOOTH_NAME="TactosyF_R"'
+	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
+	'-D BH_SERIAL_NUMBER={ 0x14, 0xb9, 0x02, 0x62, 0x41, 0xe4, 0x04, 0xb2, 0xc5, 0x11 }'
 build_src_filter  = ${bhaptics.build_src_filter}
 	+<modes/bhaptics/tactosyf.cpp>
 lib_deps    = ${bhaptics.lib_deps}
@@ -75,7 +106,7 @@ build_flags = ${bhaptics.build_flags}
 	-D BH_BLE_APPEARANCE=508
 	'-D BLUETOOTH_NAME="Tactal"'
 	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
-	'-D BH_SERIAL_NUMBER={ 0x24, 0xe6, 0xe0, 0x52, 0x3d, 0x66, 0x29, 0xc7, 0xce, 0xed }'
+	'-D BH_SERIAL_NUMBER={ 0xed, 0xcb, 0x55, 0x7c, 0xd7, 0xb9, 0x16, 0xc5, 0x18, 0x2a }'
 build_src_filter  = ${bhaptics.build_src_filter}
 	+<modes/bhaptics/tactal.cpp>
 lib_deps    = ${bhaptics.lib_deps}
@@ -85,7 +116,7 @@ build_flags = ${bhaptics.build_flags}
 	-D BH_BLE_APPEARANCE=508
 	'-D BLUETOOTH_NAME="TactGlove (L"'
 	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
-	'-D BH_SERIAL_NUMBER={ 0x24, 0xe6, 0xe0, 0x52, 0x3d, 0x66, 0x29, 0xc7, 0xce, 0xed }'
+	'-D BH_SERIAL_NUMBER={ 0xcd, 0x0b, 0x81, 0x45, 0x85, 0xf9, 0x2b, 0x6c, 0xed, 0x5b }'
 build_src_filter  = ${bhaptics.build_src_filter}
 	+<modes/bhaptics/tactglove.cpp>
 lib_deps    = ${bhaptics.lib_deps}
@@ -95,7 +126,7 @@ build_flags = ${bhaptics.build_flags}
 	-D BH_BLE_APPEARANCE=508
 	'-D BLUETOOTH_NAME="TactGlove (R"'
 	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
-	'-D BH_SERIAL_NUMBER={ 0x24, 0xe6, 0xe0, 0x52, 0x3d, 0x66, 0x29, 0xc7, 0xce, 0xed }'
+	'-D BH_SERIAL_NUMBER={ 0x12, 0x0b, 0xae, 0xbf, 0xbc, 0x90, 0x3b, 0x0d, 0x84, 0xdd }'
 build_src_filter  = ${bhaptics.build_src_filter}
 	+<modes/bhaptics/tactglove.cpp>
 lib_deps    = ${bhaptics.lib_deps}
@@ -105,7 +136,7 @@ build_flags = ${bhaptics.build_flags}
 	-D BH_BLE_APPEARANCE=508
 	'-D BLUETOOTH_NAME="Tactot DK3"'
 	'-D BH_FIRMWARE_VERSION=(uint16_t) 258'
-	'-D BH_SERIAL_NUMBER={ 0x76, 0xbd, 0xe8, 0xe7, 0x83, 0x5d, 0x8b, 0x71, 0x38, 0x1c }'
+	'-D BH_SERIAL_NUMBER={ 0x05, 0x3e, 0x60, 0x97, 0x3c, 0xbd, 0x03, 0x59, 0x14, 0xd2 }'
 build_src_filter  = ${bhaptics.build_src_filter}
 	+<modes/bhaptics/tactsuit_x40.cpp>
 lib_deps    = ${bhaptics.lib_deps}


### PR DESCRIPTION
bHaptics software uses SN to store settings for each device (position, intensity, etc)

To prevent overriding configs by connecting multiple OpenHaptics devices, each device was assigned unique SN
Additionally, CI tests were added for every known configuration